### PR TITLE
Subscription execution

### DIFF
--- a/subscription.go
+++ b/subscription.go
@@ -57,6 +57,7 @@ func (self *SubscriptableSchema) Subscribe(ctx context.Context, queryString stri
 }
 
 // Subscribe performs a subscribe operation on the given query and schema
+// To finish a subscription you can simply close the channel from inside the `Subscribe` function
 // currently does not support extensions hooks
 func Subscribe(p Params) chan *Result {
 

--- a/subscription.go
+++ b/subscription.go
@@ -224,7 +224,6 @@ func ExecuteSubscription(p ExecuteParams) chan *Result {
 			for {
 				select {
 				case <-p.Context.Done():
-					println("context cancelled")
 					// TODO send the context error to the resultchannel?
 					return
 

--- a/subscription.go
+++ b/subscription.go
@@ -92,8 +92,6 @@ func ExecuteSubscription(p ExecuteParams) chan *Result {
 		p.Context = context.Background()
 	}
 
-	// TODO run executionDidStart functions from extensions
-
 	var mapSourceToResponse = func(payload interface{}) *Result {
 		return Execute(ExecuteParams{
 			Schema:        p.Schema,
@@ -127,7 +125,6 @@ func ExecuteSubscription(p ExecuteParams) chan *Result {
 			AST:           p.AST,
 			OperationName: p.OperationName,
 			Args:          p.Args,
-			Result:        &Result{}, // TODO what is this?
 			Context:       p.Context,
 		})
 

--- a/subscription.go
+++ b/subscription.go
@@ -5,66 +5,143 @@ import (
 	"fmt"
 
 	"github.com/graphql-go/graphql/gqlerrors"
-	"github.com/graphql-go/graphql/language/ast"
+	"github.com/graphql-go/graphql/language/parser"
+	"github.com/graphql-go/graphql/language/source"
 )
 
 // SubscribeParams parameters for subscribing
 type SubscribeParams struct {
-	Schema          Schema
-	Document        *ast.Document
-	RootValue       interface{}
-	ContextValue    context.Context
+	Schema        Schema
+	RequestString string
+	RootValue     interface{}
+	// ContextValue    context.Context
 	VariableValues  map[string]interface{}
 	OperationName   string
 	FieldResolver   FieldResolveFn
 	FieldSubscriber FieldResolveFn
 }
 
+// SubscriptableSchema implements `graphql-transport-ws` `GraphQLService` interface: https://github.com/graph-gophers/graphql-transport-ws/blob/40c0484322990a129cac2f2d2763c3315230280c/graphqlws/internal/connection/connection.go#L53
+type SubscriptableSchema struct {
+	Schema     Schema
+	RootObject map[string]interface{}
+}
+
+func (self *SubscriptableSchema) Subscribe(ctx context.Context, queryString string, operationName string, variables map[string]interface{}) (<-chan *Result, error) {
+	c := Subscribe(Params{
+		Schema:         self.Schema,
+		Context:        ctx,
+		OperationName:  operationName,
+		RequestString:  queryString,
+		RootObject:     self.RootObject,
+		VariableValues: variables,
+	})
+	return c, nil
+}
+
 // Subscribe performs a subscribe operation
-func Subscribe(ctx context.Context, p SubscribeParams) chan *Result {
+func Subscribe(p Params) chan *Result {
+
+	source := source.NewSource(&source.Source{
+		Body: []byte(p.RequestString),
+		Name: "GraphQL request",
+	})
+
+	// TODO run extensions hooks
+
+	// parse the source
+	AST, err := parser.Parse(parser.ParseParams{Source: source})
+	if err != nil {
+
+		// merge the errors from extensions and the original error from parser
+		return sendOneResultandClose(&Result{
+			Errors: gqlerrors.FormatErrors(err),
+		})
+	}
+
+	// validate document
+	validationResult := ValidateDocument(&p.Schema, AST, nil)
+
+	if !validationResult.IsValid {
+		// run validation finish functions for extensions
+		return sendOneResultandClose(&Result{
+			Errors: validationResult.Errors,
+		})
+
+	}
+	return ExecuteSubscription(ExecuteParams{
+		Schema:        p.Schema,
+		Root:          p.RootObject,
+		AST:           AST,
+		OperationName: p.OperationName,
+		Args:          p.VariableValues,
+		Context:       p.Context,
+	})
+}
+
+func sendOneResultandClose(res *Result) chan *Result {
 	resultChannel := make(chan *Result)
+	resultChannel <- res
+	close(resultChannel)
+	return resultChannel
+}
+
+func ExecuteSubscription(p ExecuteParams) chan *Result {
+
+	if p.Context == nil {
+		p.Context = context.Background()
+	}
+
+	// TODO run executionDidStart functions from extensions
 
 	var mapSourceToResponse = func(payload interface{}) *Result {
 		return Execute(ExecuteParams{
 			Schema:        p.Schema,
 			Root:          payload,
-			AST:           p.Document,
+			AST:           p.AST,
 			OperationName: p.OperationName,
-			Args:          p.VariableValues,
-			Context:       p.ContextValue,
+			Args:          p.Args,
+			Context:       p.Context,
 		})
 	}
-
+	var resultChannel = make(chan *Result)
 	go func() {
-		result := &Result{}
 		defer func() {
 			if err := recover(); err != nil {
-				result.Errors = append(result.Errors, gqlerrors.FormatError(err.(error)))
-				resultChannel <- result
+				e, ok := err.(error)
+				if !ok {
+					return
+				}
+				sendOneResultandClose(&Result{
+					Errors: gqlerrors.FormatErrors(e),
+				})
 			}
-			close(resultChannel)
+			// close(resultChannel)
+			return
 		}()
 
 		exeContext, err := buildExecutionContext(buildExecutionCtxParams{
 			Schema:        p.Schema,
-			Root:          p.RootValue,
-			AST:           p.Document,
+			Root:          p.Root,
+			AST:           p.AST,
 			OperationName: p.OperationName,
-			Args:          p.VariableValues,
-			Result:        result,
-			Context:       p.ContextValue,
+			Args:          p.Args,
+			Result:        &Result{}, // TODO what is this?
+			Context:       p.Context,
 		})
 
 		if err != nil {
-			result.Errors = append(result.Errors, gqlerrors.FormatError(err.(error)))
-			resultChannel <- result
+			sendOneResultandClose(&Result{
+				Errors: gqlerrors.FormatErrors(err),
+			})
 			return
 		}
 
 		operationType, err := getOperationRootType(p.Schema, exeContext.Operation)
 		if err != nil {
-			result.Errors = append(result.Errors, gqlerrors.FormatError(err.(error)))
-			resultChannel <- result
+			sendOneResultandClose(&Result{
+				Errors: gqlerrors.FormatErrors(err),
+			})
 			return
 		}
 
@@ -85,18 +162,19 @@ func Subscribe(ctx context.Context, p SubscribeParams) chan *Result {
 		fieldDef := getFieldDef(p.Schema, operationType, fieldName)
 
 		if fieldDef == nil {
-			err := fmt.Errorf("the subscription field %q is not defined", fieldName)
-			result.Errors = append(result.Errors, gqlerrors.FormatError(err.(error)))
-			resultChannel <- result
+			sendOneResultandClose(&Result{
+				Errors: gqlerrors.FormatErrors(fmt.Errorf("the subscription field %q is not defined", fieldName)),
+			})
 			return
 		}
 
-		resolveFn := p.FieldSubscriber
+		resolveFn := fieldDef.Subscribe
+
 		if resolveFn == nil {
-			resolveFn = DefaultResolveFn
-		}
-		if fieldDef.Subscribe != nil {
-			resolveFn = fieldDef.Subscribe
+			sendOneResultandClose(&Result{
+				Errors: gqlerrors.FormatErrors(fmt.Errorf("the subscription function %q is not defined", fieldName)),
+			})
+			return
 		}
 		fieldPath := &ResponsePath{
 			Key: responseName,
@@ -117,38 +195,47 @@ func Subscribe(ctx context.Context, p SubscribeParams) chan *Result {
 		}
 
 		fieldResult, err := resolveFn(ResolveParams{
-			Source:  p.RootValue,
+			Source:  p.Root,
 			Args:    args,
 			Info:    info,
-			Context: p.ContextValue,
+			Context: p.Context,
 		})
 		if err != nil {
-			result.Errors = append(result.Errors, gqlerrors.FormatError(err.(error)))
-			resultChannel <- result
+			sendOneResultandClose(&Result{
+				Errors: gqlerrors.FormatErrors(err),
+			})
 			return
 		}
 
 		if fieldResult == nil {
-			err := fmt.Errorf("no field result")
-			result.Errors = append(result.Errors, gqlerrors.FormatError(err.(error)))
-			resultChannel <- result
+			sendOneResultandClose(&Result{
+				Errors: gqlerrors.FormatErrors(fmt.Errorf("no field result")),
+			})
 			return
 		}
 
 		switch fieldResult.(type) {
 		case chan interface{}:
 			sub := fieldResult.(chan interface{})
+			defer close(resultChannel)
 			for {
 				select {
-				case <-ctx.Done():
+				case <-p.Context.Done():
+					println("context cancelled")
+					// TODO send the context error to the resultchannel
 					return
 
-				case res := <-sub:
+				case res, more := <-sub:
+					if !more {
+						return
+					}
 					resultChannel <- mapSourceToResponse(res)
 				}
 			}
 		default:
+			fmt.Println(fieldResult)
 			resultChannel <- mapSourceToResponse(fieldResult)
+			close(resultChannel)
 			return
 		}
 	}()

--- a/subscription.go
+++ b/subscription.go
@@ -228,8 +228,7 @@ func ExecuteSubscription(p ExecuteParams) chan *Result {
 				select {
 				case <-p.Context.Done():
 					println("context cancelled")
-
-					// TODO send the context error to the resultchannel
+					// TODO send the context error to the resultchannel?
 					return
 
 				case res, more := <-sub:
@@ -243,7 +242,6 @@ func ExecuteSubscription(p ExecuteParams) chan *Result {
 		default:
 			fmt.Println(fieldResult)
 			resultChannel <- mapSourceToResponse(fieldResult)
-
 			return
 		}
 	}()

--- a/subscription.go
+++ b/subscription.go
@@ -41,14 +41,16 @@ func (self *SubscriptableSchema) Subscribe(ctx context.Context, queryString stri
 	to := make(chan interface{})
 	go func() {
 		defer close(to)
-		select {
-		case <-ctx.Done():
-			return
-		case res, more := <-c:
-			if !more {
+		for {
+			select {
+			case <-ctx.Done():
 				return
+			case res, more := <-c:
+				if !more {
+					return
+				}
+				to <- res
 			}
-			to <- res
 		}
 	}()
 	return to, nil

--- a/subscription.go
+++ b/subscription.go
@@ -110,6 +110,7 @@ func ExecuteSubscription(p ExecuteParams) chan *Result {
 			if err := recover(); err != nil {
 				e, ok := err.(error)
 				if !ok {
+					fmt.Println("strange program path")
 					return
 				}
 				sendOneResultandClose(&Result{
@@ -217,16 +218,17 @@ func ExecuteSubscription(p ExecuteParams) chan *Result {
 		switch fieldResult.(type) {
 		case chan interface{}:
 			sub := fieldResult.(chan interface{})
-			defer close(resultChannel)
 			for {
 				select {
 				case <-p.Context.Done():
 					println("context cancelled")
+					close(resultChannel)
 					// TODO send the context error to the resultchannel
 					return
 
 				case res, more := <-sub:
 					if !more {
+						close(resultChannel)
 						return
 					}
 					resultChannel <- mapSourceToResponse(res)

--- a/subscription.go
+++ b/subscription.go
@@ -95,7 +95,6 @@ func ExecuteSubscription(p ExecuteParams) chan *Result {
 			if err := recover(); err != nil {
 				e, ok := err.(error)
 				if !ok {
-					fmt.Println("strange program path")
 					return
 				}
 				resultChannel <- &Result{

--- a/subscription.go
+++ b/subscription.go
@@ -21,41 +21,6 @@ type SubscribeParams struct {
 	FieldSubscriber FieldResolveFn
 }
 
-// SubscriptableSchema implements `graphql-transport-ws` `GraphQLService` interface: https://github.com/graph-gophers/graphql-transport-ws/blob/40c0484322990a129cac2f2d2763c3315230280c/graphqlws/internal/connection/connection.go#L53
-// you can pass `SubscriptableSchema` to `graphql-transport-ws` `NewHandlerFunc`
-type SubscriptableSchema struct {
-	Schema     Schema
-	RootObject map[string]interface{}
-}
-
-// Subscribe method let you use SubscriptableSchema with graphql-transport-ws https://github.com/graph-gophers/graphql-transport-ws
-func (self *SubscriptableSchema) Subscribe(ctx context.Context, queryString string, operationName string, variables map[string]interface{}) (<-chan interface{}, error) {
-	c := Subscribe(Params{
-		Schema:         self.Schema,
-		Context:        ctx,
-		OperationName:  operationName,
-		RequestString:  queryString,
-		RootObject:     self.RootObject,
-		VariableValues: variables,
-	})
-	to := make(chan interface{})
-	go func() {
-		defer close(to)
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case res, more := <-c:
-				if !more {
-					return
-				}
-				to <- res
-			}
-		}
-	}()
-	return to, nil
-}
-
 // Subscribe performs a subscribe operation on the given query and schema
 // To finish a subscription you can simply close the channel from inside the `Subscribe` function
 // currently does not support extensions hooks

--- a/subscription.go
+++ b/subscription.go
@@ -243,7 +243,6 @@ func ExecuteSubscription(p ExecuteParams) chan *Result {
 			for {
 				select {
 				case <-p.Context.Done():
-					// TODO send the context error to the resultchannel?
 					return
 
 				case res, more := <-sub:
@@ -254,7 +253,6 @@ func ExecuteSubscription(p ExecuteParams) chan *Result {
 				}
 			}
 		default:
-			fmt.Println(fieldResult)
 			resultChannel <- mapSourceToResponse(fieldResult)
 			return
 		}

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -1,6 +1,7 @@
 package graphql_test
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -84,7 +85,7 @@ func TestSchemaSubscribe(t *testing.T) {
 			},
 		},
 		{
-			Name: "receive parse error",
+			Name: "receive query validation error",
 			Schema: makeSubscriptionSchema(t, graphql.ObjectConfig{
 				Name: "Subscription",
 				Fields: graphql.Fields{
@@ -171,52 +172,30 @@ func TestSchemaSubscribe(t *testing.T) {
 			},
 		},
 
-		// {
-		// 	Name:   "parse_errors",
-		// 	Schema: schema,
-		// 	Query:  `invalid graphQL query`,
-		// 	ExpectedResults: []testutil.TestResponse{
-		// 		{
-		// 			Errors: []gqlerrors.FormattedError{{Message: ""}},
-		// 		},
-		// 	},
-		// },
-		// {
-		// 	Name:   "subscribe_to_query_succeeds",
-		// 	Schema: schema,
-		// 	Query: `
-		// 		query Hello {
-		// 			hello
-		// 		}
-		// 	`,
-		// 	ExpectedResults: []testutil.TestResponse{
-		// 		{
-		// 			Data: json.RawMessage(`
-		// 				{
-		// 					"hello": "Hello world!"
-		// 				}
-		// 			`),
-		// 		},
-		// 	},
-		// },
-		// {
-		// 	Name:   "subscription_resolver_can_error",
-		// 	Schema: schema,
-		// 	Query: `
-		// 		subscription onHelloSaid {
-		// 			helloSaid {
-		// 				msg
-		// 			}
-		// 		}
-		// 	`,
-		// 	ExpectedResults: []testutil.TestResponse{
-		// 		{
-		// 			Data: json.RawMessage(`
-		// 				null
-		// 			`),
-		// 			Errors: []gqlerrors.FormattedError{{Message: ""}}},
-		// 	},
-		// },
+		{
+			Name: "subscription_resolver_can_error",
+			Schema: makeSubscriptionSchema(t, graphql.ObjectConfig{
+				Name: "Subscription",
+				Fields: graphql.Fields{
+					"should_error": &graphql.Field{
+						Type: graphql.String,
+						Subscribe: func(p graphql.ResolveParams) (interface{}, error) {
+							return nil, errors.New("got a subscribe error")
+						},
+					},
+				},
+			}),
+			Query: `
+				subscription {
+					should_error
+				}
+			`,
+			ExpectedResults: []testutil.TestResponse{
+				{
+					Errors: []string{"got a subscribe error"},
+				},
+			},
+		},
 		// {
 		// 	Name:   "subscription_resolver_can_error_optional_msg",
 		// 	Schema: schema,

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -84,13 +84,34 @@ func TestSchemaSubscribe(t *testing.T) {
 			},
 		},
 		{
+			Name: "receive parse error",
+			Schema: makeSubscriptionSchema(t, graphql.ObjectConfig{
+				Name: "Subscription",
+				Fields: graphql.Fields{
+					"sub_without_resolver": &graphql.Field{
+						Type:      graphql.String,
+						Subscribe: makeSubscribeToStringFunction([]string{"a", "b", "c"}),
+					},
+				},
+			}),
+			Query: `
+				subscription onHelloSaid {
+					sub_without_resolver
+					xxx
+				}
+			`,
+			ExpectedResults: []testutil.TestResponse{
+				{Errors: []string{"Cannot query field \"xxx\" on type \"Subscription\"."}},
+			},
+		},
+		{
 			Name: "subscribe with resolver changes output",
 			Schema: makeSubscriptionSchema(t, graphql.ObjectConfig{
 				Name: "Subscription",
 				Fields: graphql.Fields{
 					"sub_with_resolver": &graphql.Field{
 						Type:      graphql.String,
-						Subscribe: makeSubscribeToStringFunction([]string{"a", "b", "c"}),
+						Subscribe: makeSubscribeToStringFunction([]string{"a", "b", "c", "d"}),
 						Resolve: func(p graphql.ResolveParams) (interface{}, error) {
 							return fmt.Sprintf("result=%v", p.Source), nil
 						},
@@ -106,6 +127,7 @@ func TestSchemaSubscribe(t *testing.T) {
 				{Data: `{ "sub_with_resolver": "result=a" }`},
 				{Data: `{ "sub_with_resolver": "result=b" }`},
 				{Data: `{ "sub_with_resolver": "result=c" }`},
+				{Data: `{ "sub_with_resolver": "result=d" }`},
 			},
 		},
 		{

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -155,6 +155,9 @@ func TestSchemaSubscribe(t *testing.T) {
 							{
 								"field": "bye",
 							},
+							{
+								"field": nil,
+							},
 						}),
 					},
 				},
@@ -169,6 +172,7 @@ func TestSchemaSubscribe(t *testing.T) {
 			ExpectedResults: []testutil.TestResponse{
 				{Data: `{ "sub_with_object": { "field": "hello" } }`},
 				{Data: `{ "sub_with_object": { "field": "bye" } }`},
+				{Data: `{ "sub_with_object": { "field": null } }`},
 			},
 		},
 
@@ -196,60 +200,28 @@ func TestSchemaSubscribe(t *testing.T) {
 				},
 			},
 		},
-		// {
-		// 	Name:   "subscription_resolver_can_error_optional_msg",
-		// 	Schema: schema,
-		// 	Query: `
-		// 		subscription onHelloSaid {
-		// 			helloSaidNullable {
-		// 				msg
-		// 			}
-		// 		}
-		// 	`,
-		// 	ExpectedResults: []testutil.TestResponse{
-		// 		{
-		// 			Data: json.RawMessage(`
-		// 				{
-		// 					"helloSaidNullable": {
-		// 						"msg": null
-		// 					}
-		// 				}
-		// 			`),
-		// 			Errors: []gqlerrors.FormattedError{{Message: ""}}},
-		// 	},
-		// },
-		// {
-		// 	Name:   "subscription_resolver_can_error_optional_event",
-		// 	Schema: schema,
-		// 	Query: `
-		// 		subscription onHelloSaid {
-		// 			helloSaidNullable {
-		// 				msg
-		// 			}
-		// 		}
-		// 	`,
-		// 	ExpectedResults: []testutil.TestResponse{
-		// 		{
-		// 			Data: json.RawMessage(`
-		// 				{
-		// 					"helloSaidNullable": null
-		// 				}
-		// 			`),
-		// 			Errors: []gqlerrors.FormattedError{{Message: ""}}},
-		// 	},
-		// },
-		// {
-		// 	Name:   "schema_without_resolver_errors",
-		// 	Schema: schema,
-		// 	Query: `
-		// 		subscription onHelloSaid {
-		// 			helloSaid {
-		// 				msg
-		// 			}
-		// 		}
-		// 	`,
-		// 	ExpectedErr: errors.New("schema created without resolver, can not subscribe"),
-		// },
+
+		{
+			Name: "schema_without_subscribe_errors",
+			Schema: makeSubscriptionSchema(t, graphql.ObjectConfig{
+				Name: "Subscription",
+				Fields: graphql.Fields{
+					"should_error": &graphql.Field{
+						Type: graphql.String,
+					},
+				},
+			}),
+			Query: `
+				subscription {
+					should_error
+				}
+			`,
+			ExpectedResults: []testutil.TestResponse{
+				{
+					Errors: []string{"the subscription function \"should_error\" is not defined"},
+				},
+			},
+		},
 	})
 }
 

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -1,144 +1,308 @@
-package graphql
+package graphql_test
 
 import (
-	"context"
 	"fmt"
 	"testing"
-	"time"
 
-	"github.com/graphql-go/graphql/language/parser"
-	"github.com/graphql-go/graphql/language/source"
+	"github.com/graphql-go/graphql"
+	"github.com/graphql-go/graphql/testutil"
 )
 
-func TestSubscription(t *testing.T) {
-	var maxPublish = 5
-	m := make(chan interface{})
+func makeSubscribeToStringFunction(elements []string) func(p graphql.ResolveParams) (interface{}, error) {
+	return func(p graphql.ResolveParams) (interface{}, error) {
+		c := make(chan interface{})
+		go func() {
+			for _, r := range elements {
+				select {
+				case <-p.Context.Done():
+					close(c)
+					return
+				case c <- r:
+				}
+			}
+			close(c)
+		}()
+		return c, nil
+	}
+}
 
-	source1 := source.NewSource(&source.Source{
-		Body: []byte(`subscription {
-			watch_count
-		}`),
-		Name: "GraphQL request",
+func makeSubscribeToMapFunction(elements []map[string]interface{}) func(p graphql.ResolveParams) (interface{}, error) {
+	return func(p graphql.ResolveParams) (interface{}, error) {
+		c := make(chan interface{})
+		go func() {
+			for _, r := range elements {
+				select {
+				case <-p.Context.Done():
+					close(c)
+					return
+				case c <- r:
+				}
+			}
+			close(c)
+		}()
+		return c, nil
+	}
+}
+
+func makeSubscriptionSchema(t *testing.T, c graphql.ObjectConfig) graphql.Schema {
+	schema, err := graphql.NewSchema(graphql.SchemaConfig{
+		Query:        dummyQuery,
+		Subscription: graphql.NewObject(c),
 	})
-
-	source2 := source.NewSource(&source.Source{
-		Body: []byte(`subscription {
-			watch_should_fail
-		}`),
-		Name: "GraphQL request",
-	})
-
-	document1, _ := parser.Parse(parser.ParseParams{Source: source1})
-	document2, _ := parser.Parse(parser.ParseParams{Source: source2})
-
-	schema, err := NewSchema(SchemaConfig{
-		Query: NewObject(ObjectConfig{
-			Name: "Query",
-			Fields: Fields{
-				"hello": &Field{
-					Type: String,
-					Resolve: func(p ResolveParams) (interface{}, error) {
-						return "world", nil
-					},
-				},
-			},
-		}),
-		Subscription: NewObject(ObjectConfig{
-			Name: "Subscription",
-			Fields: Fields{
-				"watch_count": &Field{
-					Type: String,
-					Resolve: func(p ResolveParams) (interface{}, error) {
-						return fmt.Sprintf("count=%v", p.Source), nil
-					},
-					Subscribe: func(p ResolveParams) (interface{}, error) {
-						return m, nil
-					},
-				},
-				"watch_should_fail": &Field{
-					Type: String,
-					Resolve: func(p ResolveParams) (interface{}, error) {
-						return fmt.Sprintf("count=%v", p.Source), nil
-					},
-					Subscribe: func(p ResolveParams) (interface{}, error) {
-						return nil, nil
-					},
-				},
-			},
-		}),
-	})
-
 	if err != nil {
 		t.Errorf("failed to create schema: %v", err)
-		return
 	}
-
-	// test a subscribe that should fail due to no return value
-	fctx, fCancelFunc := context.WithCancel(context.Background())
-	fail := Subscribe(fctx, SubscribeParams{
-		Schema:   schema,
-		Document: document2,
-	})
-
-	go func() {
-		for {
-			result := <-fail
-			if !result.HasErrors() {
-				t.Errorf("subscribe failed to catch nil result from subscribe")
-			}
-			fCancelFunc()
-			return
-		}
-	}()
-
-	// test subscription data
-	resultCount := 0
-	rctx, rCancelFunc := context.WithCancel(context.Background())
-	results := Subscribe(rctx, SubscribeParams{
-		Schema:       schema,
-		Document:     document1,
-		ContextValue: context.Background(),
-	})
-
-	go func() {
-		for {
-			result := <-results
-			if result.HasErrors() {
-				t.Errorf("subscribe error(s): %v", result.Errors)
-				rCancelFunc()
-				return
-			}
-
-			if result.Data != nil {
-				resultCount++
-				data := result.Data.(map[string]interface{})["watch_count"]
-				expected := fmt.Sprintf("count=%d", resultCount)
-				actual := fmt.Sprintf("%v", data)
-				if actual != expected {
-					t.Errorf("subscription result error: expected %q, actual %q", expected, actual)
-					rCancelFunc()
-					return
-				}
-
-				// test the done func by quitting after 3 iterations
-				// the publisher will publish up to 5
-				if resultCount >= maxPublish-2 {
-					rCancelFunc()
-					return
-				}
-			}
-		}
-	}()
-
-	// start publishing
-	go func() {
-		for i := 1; i <= maxPublish; i++ {
-			time.Sleep(200 * time.Millisecond)
-			m <- i
-		}
-		close(m)
-	}()
-
-	// give time for the test to complete
-	time.Sleep(1 * time.Second)
+	return schema
 }
+
+func TestSchemaSubscribe(t *testing.T) {
+
+	testutil.RunSubscribes(t, []*testutil.TestSubscription{
+		{
+			Name: "subscribe without resolver",
+			Schema: makeSubscriptionSchema(t, graphql.ObjectConfig{
+				Name: "Subscription",
+				Fields: graphql.Fields{
+					"sub_without_resolver": &graphql.Field{
+						Type:      graphql.String,
+						Subscribe: makeSubscribeToStringFunction([]string{"a", "b", "c"}),
+						Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+							return p.Source, nil
+						},
+					},
+				},
+			}),
+			Query: `
+				subscription onHelloSaid {
+					sub_without_resolver
+				}
+			`,
+			ExpectedResults: []testutil.TestResponse{
+				{Data: `{ "sub_without_resolver": "a" }`},
+				{Data: `{ "sub_without_resolver": "b" }`},
+				{Data: `{ "sub_without_resolver": "c" }`},
+			},
+		},
+		{
+			Name: "subscribe with resolver changes output",
+			Schema: makeSubscriptionSchema(t, graphql.ObjectConfig{
+				Name: "Subscription",
+				Fields: graphql.Fields{
+					"sub_with_resolver": &graphql.Field{
+						Type:      graphql.String,
+						Subscribe: makeSubscribeToStringFunction([]string{"a", "b", "c"}),
+						Resolve: func(p graphql.ResolveParams) (interface{}, error) {
+							return fmt.Sprintf("result=%v", p.Source), nil
+						},
+					},
+				},
+			}),
+			Query: `
+				subscription onHelloSaid {
+					sub_with_resolver
+				}
+			`,
+			ExpectedResults: []testutil.TestResponse{
+				{Data: `{ "sub_with_resolver": "result=a" }`},
+				{Data: `{ "sub_with_resolver": "result=b" }`},
+				{Data: `{ "sub_with_resolver": "result=c" }`},
+			},
+		},
+		// {
+		// 	Name: "subscribe to a nested object",
+		// 	Schema: makeSubscriptionSchema(t, graphql.ObjectConfig{
+		// 		Name: "Subscription",
+		// 		Fields: graphql.Fields{
+		// 			"sub_with_object": &graphql.Field{
+		// 				Type: graphql.String,
+		// 				Subscribe: makeSubscribeToMapFunction([]map[string]interface{}{
+		// 					{
+		// 						"field": "hello",
+		// 						"obj": map[string]interface{}{
+		// 							"field": "hello",
+		// 						},
+		// 					},
+		// 					{
+		// 						"field": "bye",
+		// 						"obj": map[string]interface{}{
+		// 							"field": "bye",
+		// 						},
+		// 					},
+		// 				}),
+		// 			},
+		// 		},
+		// 	}),
+		// 	Query: `
+		// 		subscription onHelloSaid {
+		// 			sub_with_object {
+		// 				field
+		// 				obj {
+		// 					field
+		// 				}
+		// 			}
+		// 		}
+		// 	`,
+		// 	ExpectedResults: []testutil.TestResponse{
+		// 		{Data: `{ "sub_with_object": { "field": "hello", "obj": { "field": "hello" } } }`},
+		// 	},
+		// },
+
+		// {
+		// 	Name:   "parse_errors",
+		// 	Schema: schema,
+		// 	Query:  `invalid graphQL query`,
+		// 	ExpectedResults: []testutil.TestResponse{
+		// 		{
+		// 			Errors: []gqlerrors.FormattedError{{Message: ""}},
+		// 		},
+		// 	},
+		// },
+		// {
+		// 	Name:   "subscribe_to_query_succeeds",
+		// 	Schema: schema,
+		// 	Query: `
+		// 		query Hello {
+		// 			hello
+		// 		}
+		// 	`,
+		// 	ExpectedResults: []testutil.TestResponse{
+		// 		{
+		// 			Data: json.RawMessage(`
+		// 				{
+		// 					"hello": "Hello world!"
+		// 				}
+		// 			`),
+		// 		},
+		// 	},
+		// },
+		// {
+		// 	Name:   "subscription_resolver_can_error",
+		// 	Schema: schema,
+		// 	Query: `
+		// 		subscription onHelloSaid {
+		// 			helloSaid {
+		// 				msg
+		// 			}
+		// 		}
+		// 	`,
+		// 	ExpectedResults: []testutil.TestResponse{
+		// 		{
+		// 			Data: json.RawMessage(`
+		// 				null
+		// 			`),
+		// 			Errors: []gqlerrors.FormattedError{{Message: ""}}},
+		// 	},
+		// },
+		// {
+		// 	Name:   "subscription_resolver_can_error_optional_msg",
+		// 	Schema: schema,
+		// 	Query: `
+		// 		subscription onHelloSaid {
+		// 			helloSaidNullable {
+		// 				msg
+		// 			}
+		// 		}
+		// 	`,
+		// 	ExpectedResults: []testutil.TestResponse{
+		// 		{
+		// 			Data: json.RawMessage(`
+		// 				{
+		// 					"helloSaidNullable": {
+		// 						"msg": null
+		// 					}
+		// 				}
+		// 			`),
+		// 			Errors: []gqlerrors.FormattedError{{Message: ""}}},
+		// 	},
+		// },
+		// {
+		// 	Name:   "subscription_resolver_can_error_optional_event",
+		// 	Schema: schema,
+		// 	Query: `
+		// 		subscription onHelloSaid {
+		// 			helloSaidNullable {
+		// 				msg
+		// 			}
+		// 		}
+		// 	`,
+		// 	ExpectedResults: []testutil.TestResponse{
+		// 		{
+		// 			Data: json.RawMessage(`
+		// 				{
+		// 					"helloSaidNullable": null
+		// 				}
+		// 			`),
+		// 			Errors: []gqlerrors.FormattedError{{Message: ""}}},
+		// 	},
+		// },
+		// {
+		// 	Name:   "schema_without_resolver_errors",
+		// 	Schema: schema,
+		// 	Query: `
+		// 		subscription onHelloSaid {
+		// 			helloSaid {
+		// 				msg
+		// 			}
+		// 		}
+		// 	`,
+		// 	ExpectedErr: errors.New("schema created without resolver, can not subscribe"),
+		// },
+	})
+}
+
+// func TestRootOperations_invalidSubscriptionSchema(t *testing.T) {
+// 	type args struct {
+// 		Schema string
+// 	}
+// 	type want struct {
+// 		Error string
+// 	}
+// 	testTable := map[string]struct {
+// 		Args args
+// 		Want want
+// 	}{
+// 		"Subscription as incorrect type": {
+// 			Args: args{
+// 				Schema: `
+// 					schema {
+// 						query: Query
+// 						subscription: String
+// 					}
+// 					type Query {
+// 						thing: String
+// 					}
+// 				`,
+// 			},
+// 			Want: want{Error: `root operation "subscription" must be an OBJECT`},
+// 		},
+// 		"Subscription declared by schema, but type not present": {
+// 			Args: args{
+// 				Schema: `
+// 					schema {
+// 						query: Query
+// 						subscription: Subscription
+// 					}
+// 					type Query {
+// 						hello: String!
+// 					}
+// 				`,
+// 			},
+// 			Want: want{Error: `graphql: type "Subscription" not found`},
+// 		},
+// 	}
+
+// 	for name, tt := range testTable {
+// 		tt := tt
+// 		t.Run(name, func(t *testing.T) {
+// 			t.Log(tt.Args.Schema) // TODO do something
+// 		})
+// 	}
+// }
+
+var dummyQuery = graphql.NewObject(graphql.ObjectConfig{
+	Name: "Query",
+	Fields: graphql.Fields{
+
+		"hello": &graphql.Field{Type: graphql.String},
+	},
+})

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -9,53 +9,6 @@ import (
 	"github.com/graphql-go/graphql/testutil"
 )
 
-func makeSubscribeToStringFunction(elements []string) func(p graphql.ResolveParams) (interface{}, error) {
-	return func(p graphql.ResolveParams) (interface{}, error) {
-		c := make(chan interface{})
-		go func() {
-			for _, r := range elements {
-				select {
-				case <-p.Context.Done():
-					close(c)
-					return
-				case c <- r:
-				}
-			}
-			close(c)
-		}()
-		return c, nil
-	}
-}
-
-func makeSubscribeToMapFunction(elements []map[string]interface{}) func(p graphql.ResolveParams) (interface{}, error) {
-	return func(p graphql.ResolveParams) (interface{}, error) {
-		c := make(chan interface{})
-		go func() {
-			for _, r := range elements {
-				select {
-				case <-p.Context.Done():
-					close(c)
-					return
-				case c <- r:
-				}
-			}
-			close(c)
-		}()
-		return c, nil
-	}
-}
-
-func makeSubscriptionSchema(t *testing.T, c graphql.ObjectConfig) graphql.Schema {
-	schema, err := graphql.NewSchema(graphql.SchemaConfig{
-		Query:        dummyQuery,
-		Subscription: graphql.NewObject(c),
-	})
-	if err != nil {
-		t.Errorf("failed to create schema: %v", err)
-	}
-	return schema
-}
-
 func TestSchemaSubscribe(t *testing.T) {
 
 	testutil.RunSubscribes(t, []*testutil.TestSubscription{
@@ -200,7 +153,6 @@ func TestSchemaSubscribe(t *testing.T) {
 				},
 			},
 		},
-
 		{
 			Name: "schema_without_subscribe_errors",
 			Schema: makeSubscriptionSchema(t, graphql.ObjectConfig{
@@ -225,54 +177,52 @@ func TestSchemaSubscribe(t *testing.T) {
 	})
 }
 
-// func TestRootOperations_invalidSubscriptionSchema(t *testing.T) {
-// 	type args struct {
-// 		Schema string
-// 	}
-// 	type want struct {
-// 		Error string
-// 	}
-// 	testTable := map[string]struct {
-// 		Args args
-// 		Want want
-// 	}{
-// 		"Subscription as incorrect type": {
-// 			Args: args{
-// 				Schema: `
-// 					schema {
-// 						query: Query
-// 						subscription: String
-// 					}
-// 					type Query {
-// 						thing: String
-// 					}
-// 				`,
-// 			},
-// 			Want: want{Error: `root operation "subscription" must be an OBJECT`},
-// 		},
-// 		"Subscription declared by schema, but type not present": {
-// 			Args: args{
-// 				Schema: `
-// 					schema {
-// 						query: Query
-// 						subscription: Subscription
-// 					}
-// 					type Query {
-// 						hello: String!
-// 					}
-// 				`,
-// 			},
-// 			Want: want{Error: `graphql: type "Subscription" not found`},
-// 		},
-// 	}
+func makeSubscribeToStringFunction(elements []string) func(p graphql.ResolveParams) (interface{}, error) {
+	return func(p graphql.ResolveParams) (interface{}, error) {
+		c := make(chan interface{})
+		go func() {
+			for _, r := range elements {
+				select {
+				case <-p.Context.Done():
+					close(c)
+					return
+				case c <- r:
+				}
+			}
+			close(c)
+		}()
+		return c, nil
+	}
+}
 
-// 	for name, tt := range testTable {
-// 		tt := tt
-// 		t.Run(name, func(t *testing.T) {
-// 			t.Log(tt.Args.Schema) // TODO do something
-// 		})
-// 	}
-// }
+func makeSubscribeToMapFunction(elements []map[string]interface{}) func(p graphql.ResolveParams) (interface{}, error) {
+	return func(p graphql.ResolveParams) (interface{}, error) {
+		c := make(chan interface{})
+		go func() {
+			for _, r := range elements {
+				select {
+				case <-p.Context.Done():
+					close(c)
+					return
+				case c <- r:
+				}
+			}
+			close(c)
+		}()
+		return c, nil
+	}
+}
+
+func makeSubscriptionSchema(t *testing.T, c graphql.ObjectConfig) graphql.Schema {
+	schema, err := graphql.NewSchema(graphql.SchemaConfig{
+		Query:        dummyQuery,
+		Subscription: graphql.NewObject(c),
+	})
+	if err != nil {
+		t.Errorf("failed to create schema: %v", err)
+	}
+	return schema
+}
 
 var dummyQuery = graphql.NewObject(graphql.ObjectConfig{
 	Name: "Query",

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -34,7 +34,7 @@ func TestSchemaSubscribe(t *testing.T) {
 				},
 			}),
 			Query: `
-				subscription onHelloSaid {
+				subscription {
 					sub_without_resolver
 				}
 			`,
@@ -59,7 +59,7 @@ func TestSchemaSubscribe(t *testing.T) {
 				},
 			}),
 			Query: `
-				subscription onHelloSaid {
+				subscription {
 					sub_with_resolver
 				}
 			`,
@@ -81,13 +81,35 @@ func TestSchemaSubscribe(t *testing.T) {
 				},
 			}),
 			Query: `
-				subscription onHelloSaid {
+				subscription {
 					sub_without_resolver
 					xxx
 				}
 			`,
 			ExpectedResults: []testutil.TestResponse{
 				{Errors: []string{"Cannot query field \"xxx\" on type \"Subscription\"."}},
+			},
+		},
+		{
+			Name: "panic inside subscribe is recovered",
+			Schema: makeSubscriptionSchema(t, graphql.ObjectConfig{
+				Name: "Subscription",
+				Fields: graphql.Fields{
+					"should_error": &graphql.Field{
+						Type: graphql.String,
+						Subscribe: func(p graphql.ResolveParams) (interface{}, error) {
+							panic(errors.New("got a panic error"))
+						},
+					},
+				},
+			}),
+			Query: `
+				subscription {
+					should_error
+				}
+			`,
+			ExpectedResults: []testutil.TestResponse{
+				{Errors: []string{"got a panic error"}},
 			},
 		},
 		{
@@ -105,7 +127,7 @@ func TestSchemaSubscribe(t *testing.T) {
 				},
 			}),
 			Query: `
-				subscription onHelloSaid {
+				subscription {
 					sub_with_resolver
 				}
 			`,
@@ -148,7 +170,7 @@ func TestSchemaSubscribe(t *testing.T) {
 				},
 			}),
 			Query: `
-				subscription onHelloSaid {
+				subscription {
 					sub_with_object {
 						field
 					}

--- a/testutil/subscription.go
+++ b/testutil/subscription.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"strconv"
 	"testing"
 
@@ -65,7 +64,7 @@ func RunSubscribe(t *testing.T, test *TestSubscription) {
 
 	var results []*graphql.Result
 	for res := range c {
-		fmt.Println(res)
+		println(pretty(res))
 		results = append(results, res)
 	}
 
@@ -138,4 +137,12 @@ func formatJSON(data string) ([]byte, error) {
 		return nil, err
 	}
 	return formatted, nil
+}
+
+func pretty(x interface{}) string {
+	got, err := json.MarshalIndent(x, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	return string(got)
 }

--- a/testutil/subscription.go
+++ b/testutil/subscription.go
@@ -62,7 +62,7 @@ func RunSubscribe(t *testing.T, test *TestSubscription) {
 
 	var results []*graphql.Result
 	for res := range c {
-		println(pretty(res))
+		t.Log(pretty(res))
 		results = append(results, res)
 	}
 

--- a/testutil/subscription.go
+++ b/testutil/subscription.go
@@ -1,0 +1,141 @@
+package testutil
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/graphql-go/graphql"
+	"github.com/graphql-go/graphql/gqlerrors"
+)
+
+// TestResponse models the expected response
+type TestResponse struct {
+	Data   string
+	Errors []gqlerrors.FormattedError
+}
+
+// TestSubscription is a GraphQL test case to be used with RunSubscribe.
+type TestSubscription struct {
+	Name            string
+	Schema          graphql.Schema
+	Query           string
+	OperationName   string
+	Variables       map[string]interface{}
+	ExpectedResults []TestResponse
+	ExpectedErr     error
+}
+
+// RunSubscribes runs the given GraphQL subscription test cases as subtests.
+func RunSubscribes(t *testing.T, tests []*TestSubscription) {
+	for i, test := range tests {
+		if test.Name == "" {
+			test.Name = strconv.Itoa(i + 1)
+		}
+
+		t.Run(test.Name, func(t *testing.T) {
+			RunSubscribe(t, test)
+		})
+	}
+}
+
+// RunSubscribe runs a single GraphQL subscription test case.
+func RunSubscribe(t *testing.T, test *TestSubscription) {
+	ctx, _ := context.WithCancel(context.Background())
+	// defer cancel() // TODO add defer cancel
+
+	c := graphql.Subscribe(graphql.Params{
+		Context:        ctx,
+		OperationName:  test.OperationName,
+		RequestString:  test.Query,
+		VariableValues: test.Variables,
+		Schema:         test.Schema,
+	})
+	// if err != nil {
+	// 	if err.Error() != test.ExpectedErr.Error() {
+	// 		t.Fatalf("unexpected error: got %+v, want %+v", err, test.ExpectedErr)
+	// 	}
+
+	// 	return
+	// }
+
+	var results []*graphql.Result
+	for res := range c {
+		fmt.Println(res)
+		results = append(results, res)
+	}
+
+	for i, expected := range test.ExpectedResults {
+		if len(results)-1 < i {
+			t.Error(errors.New("not enough results, expected results are more than actual results"))
+			return
+		}
+		res := results[i]
+
+		checkErrorStrings(t, expected.Errors, res.Errors)
+
+		resData, err := json.MarshalIndent(res.Data, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		got, err := json.MarshalIndent(res.Data, "", "  ")
+		if err != nil {
+			t.Fatalf("got: invalid JSON: %s; raw: %s", err, resData)
+		}
+
+		if err != nil {
+			t.Fatal(err)
+		}
+		want, err := formatJSON(expected.Data)
+		if err != nil {
+			t.Fatalf("got: invalid JSON: %s; raw: %s", err, res.Data)
+		}
+
+		if !bytes.Equal(got, want) {
+			t.Logf("got:  %s", got)
+			t.Logf("want: %s", want)
+			t.Fail()
+		}
+	}
+}
+
+func checkErrorStrings(t *testing.T, expected, actual []gqlerrors.FormattedError) {
+	expectedCount, actualCount := len(expected), len(actual)
+
+	if expectedCount != actualCount {
+		t.Fatalf("unexpected number of errors: want %d, got %d", expectedCount, actualCount)
+	}
+
+	if expectedCount > 0 {
+		for i, want := range expected {
+			got := actual[i]
+
+			if got.Error() != want.Error() {
+				t.Fatalf("unexpected error: got %+v, want %+v", got, want)
+			}
+		}
+
+		// Return because we're done checking.
+		return
+	}
+
+	for _, err := range actual {
+		t.Errorf("unexpected error: '%s'", err)
+	}
+}
+
+func formatJSON(data string) ([]byte, error) {
+	var v interface{}
+	if err := json.Unmarshal([]byte(data), &v); err != nil {
+		return nil, err
+	}
+	formatted, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return nil, err
+	}
+	return formatted, nil
+}


### PR DESCRIPTION
What i changed
- split the `Subscribe` function in `Subscribe` (similar to `graphql.Do`) and `ExecuteSubscription` (similar to `graphql.Execute`)
- Subscribe now does the parsing and validation, more similar to `graphql.Do`
- removed the added context as there was already one in the params
- rewritten tests as a grid
- added testutils for subscriptions tests
- added a `SubscriptableSchema` that can be used with https://github.com/graph-gophers/graphql-transport-ws

I still have to check if it works ok with the https://github.com/graph-gophers/graphql-transport-ws handler
